### PR TITLE
fix: close streams properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitswap-peer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/util-dynamodb": "^3.118.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitswap-peer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Elastic IPFS BitSwap Peer",
   "homepage": "https://github.com/elastic-ipfs/bitswap-peer",
   "repository": "github:web3-storage/bitswap-peer",

--- a/src/service.js
+++ b/src/service.js
@@ -263,6 +263,11 @@ async function startService({ peerId, currentPort, dispatcher, announceAddr } = 
           }
         })
 
+        // When the incoming duplex stream finishes sending, close for writing.
+        // Note: we never write to this stream - responses are always sent on
+        // another multiplexed stream.
+        connection.on('end:receive', () => connection.close())
+
         /* c8 ignore next 4 */
         connection.on('error', err => {
           logger.error({ err, dial, stream, protocol }, `Connection error: ${serializeError(err)}`)


### PR DESCRIPTION
This PR fixes closing incoming and outgoing duplex streams properly. This will hopefully resolve at least 1 memory leak.

There were 2 issues here:

1. For incoming streams, we never closed our side for writing. i.e. when we got a new incoming stream and finished receiving all the data we didn't close our side for writing (and we don't write to the incoming stream anyway).
2. For outgoing streams, we never closed our side for reading. i.e. the stream was held open, awaiting a read (and we never read anything when sending data back to the peer anyway).

