### PR TITLE
feat: add LRU block data cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ _Variables in bold are required._
 | AWS_REGION            |               | The AWS region.                                                          |
 | AWS_SECRET_ACCESS_KEY |               | The AWS access key.                                                      |
 | CACHE_BLOCKS_INFO     | `false`       | Set to `true` to cache block informations with in a in-memory LRU cache. |
-| CACHE_BLOCKS_SIZE     | `1e3`         | Max entries of the cache.                                                |
+| CACHE_BLOCKS_SIZE     | `1e3`         | Max entries of the block info cache.                                     |
+| CACHE_BLOCK_DATA      | `false`       | Set to `true` to cache block data with in a in-memory LRU cache.         |
+| CACHE_BLOCK_DATA_SIZE | `1000`        | Max entries of the block data cache.                                     |
 | CONCURRENCY           | `128`         | The maximum concurrency when searching CIDs.                             |
 | DYNAMO_BLOCKS_TABLE   | `blocks`      | The DynamoDB table where store CIDs informations to.                     |
 | DYNAMO_CARS_TABLE     | `cars`        | The DynamoDB table where store CAR files informations to.                |

--- a/metrics.yml
+++ b/metrics.yml
@@ -10,5 +10,7 @@ metrics:
   bitswap-sent-data: BitSwap Sent Data, in bytes
   s3-fetchs: AWS S3 GetObject
   dynamo-reads: AWS DynamoDB GetItem
+  cache-block-data-hits: LRU cache hits for block data
+  cache-block-data-misses: LRU cache misses for block data
 version: 0.1.0
 buildDate: "20220307.1423"

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,9 @@ const {
   CACHE_BLOCKS_INFO: cacheBlocksInfo,
   CACHE_BLOCKS_SIZE: cacheBlocksSize,
 
+  CACHE_BLOCK_DATA: cacheBlockData,
+  CACHE_BLOCK_DATA_SIZE: cacheBlockDataSize,
+
   CONCURRENCY: rawConcurrency,
 
   DYNAMO_BLOCKS_TABLE: blocksTable,
@@ -40,6 +43,9 @@ module.exports = {
   blocksTable: blocksTable ?? 'blocks',
   cacheBlocksInfo: cacheBlocksInfo === 'true',
   cacheBlocksSize: cacheBlocksSize ?? 1e3,
+
+  cacheBlockData: cacheBlockData === 'true',
+  cacheBlockDataSize: cacheBlockDataSize ? parseInt(cacheBlockDataSize) : 1e3,
 
   carsTable: carsTable ?? 'cars',
   blocksTableV1: blocksTableV1 ?? 'v1-blocks',

--- a/src/service.js
+++ b/src/service.js
@@ -69,8 +69,10 @@ async function fetchBlock(dispatcher, cid) {
   if (cacheBlockData) {
     const bytes = blockDataCache.get(cacheKey)
     if (bytes) {
+      telemetry.increaseCount('cache-block-data-hits')
       return bytes
     }
+    telemetry.increaseCount('cache-block-data-misses')
   }
 
   const [, bucketRegion, bucketName, key] = car.match(/([^/]+)\/([^/]+)\/(.+)/)

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 process.env.CACHE_BLOCKS_INFO = 'true'
+process.env.CACHE_BLOCK_DATA = 'true'
 process.env.LOG_LEVEL = 'fatal'
 
 const { once } = require('events')
@@ -9,7 +10,7 @@ const t = require('tap')
 const { port } = require('../src/config')
 const { BITSWAP_V_100: protocol, Entry, Message, WantList } = require('../src/protocol')
 const { startService } = require('../src/service')
-const { cid1, cid1Content } = require('./fixtures/cids')
+const { cid1, cid1Content, cid2 } = require('./fixtures/cids')
 const { hasRawBlock, prepare, receiveMessages, teardown } = require('./utils/helpers')
 const { createMockAgent, mockAWS } = require('./utils/mock')
 
@@ -81,7 +82,8 @@ t.test('service - handles blocks error', async t => {
 
   const { client, service, connection, receiver } = await prepare(t, protocol, mockAgent)
 
-  const wantList = new WantList([new Entry(cid1, 1, false, Entry.WantType.Block, true)], false)
+  // Use CID2, which is not already cached by the tests above
+  const wantList = new WantList([new Entry(cid2, 1, false, Entry.WantType.Block, true)], false)
 
   const request = new Message(wantList, [], [], 0)
   await connection.send(request.encode(protocol))


### PR DESCRIPTION
This PR adds an LRU block data cache. I realised we only have an LRU cache for block _info_ not block _data_ 🤦‍♂️.

The default size of this cache is 1,000 items which is...tiny. Blocks in dotstorage currently cannot be >1MB in size so as a rough guide we might want to add about 500MB of memory for every 1,000 items as typically blocks will be significantly smaller than 1MB (256kb for regular IPFS blocks).

Aside, why didn't we use https://www.npmjs.com/package/lru-cache? The one we're using only allows us to set the number of items and I'd ideally like to set the maximum byte size. Maybe that can be changed in a follow up PR.

Once this is merged, I'd like to follow up with a PR to prefetch blocks into the cache.