### PR TITLE
feat: options for peers keep-alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _Variables in bold are required._
 | PEER_ID_S3_BUCKET     |               | The S3 bucket to download the BitSwap PeerID in JSON format.             |
 | PEER_ANNOUNCE_ADDR    |               | Swarm multiaddr to announce to the network (excluding peer ID).          |
 | PIPELINING            | `16`          | The maximum request to pipeline in a single HTTP connections in AWS.     |
+| ENABLE_KEEP_ALIVE   | `false`          | Enable Keep-alive for peers                       |
 | PING_PERIOD_SECONDS   | `10`          | Wait interval for ping connected peer (Keep Alive)                       |
 | PORT                  | `3000`        | The port number to listen on.                                            |
 | TELEMETRY_PORT        | `3001`        | The telemetry port number for the OpenTelemetry server to listen on.     |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitswap-peer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/util-dynamodb": "^3.118.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitswap-peer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Elastic IPFS BitSwap Peer",
   "homepage": "https://github.com/elastic-ipfs/bitswap-peer",
   "repository": "github:web3-storage/bitswap-peer",

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,8 @@ const {
   PIPELINING: rawPipelining,
   PORT: rawPort,
   HTTP_PORT: rawHttpPort,
+
+  ENABLE_KEEP_ALIVE: enableKeepAlive,
   PING_PERIOD_SECONDS: pingPeriodSecs,
 
   DYNAMO_MAX_RETRIES: dynamoMaxRetries,
@@ -57,7 +59,9 @@ module.exports = {
   linkTableBlockKey: 'blockmultihash',
   linkTableCarKey: 'carpath',
 
+  enableKeepAlive: enableKeepAlive === 'true',
   pingPeriodSecs: pingPeriodSecs ?? 10,
+  
   concurrency: !isNaN(concurrency) && concurrency > 0 ? concurrency : 128,
   peerIdJsonFile,
   peerIdJsonPath: join(peerIdJsonDirectory ?? '/tmp', peerIdJsonFile ?? 'peerId.json'),

--- a/src/config.js
+++ b/src/config.js
@@ -61,7 +61,7 @@ module.exports = {
 
   enableKeepAlive: enableKeepAlive === 'true',
   pingPeriodSecs: pingPeriodSecs ?? 10,
-  
+
   concurrency: !isNaN(concurrency) && concurrency > 0 ? concurrency : 128,
   peerIdJsonFile,
   peerIdJsonPath: join(peerIdJsonDirectory ?? '/tmp', peerIdJsonFile ?? 'peerId.json'),

--- a/src/service.js
+++ b/src/service.js
@@ -12,6 +12,7 @@ const { Connection } = require('./networking')
 const { noiseCrypto } = require('./noise-crypto')
 const { getPeerId } = require('../src/peer-id')
 const { startKeepAlive, stopKeepAlive } = require('./p2p-keep-alive.js')
+const { enableKeepAlive } = require('./config')
 const {
   BITSWAP_V_120,
   Block,
@@ -301,7 +302,7 @@ async function startService({ peerId, currentPort, dispatcher, announceAddr } = 
 
     service.connectionManager.on('peer:connect', connection => {
       try {
-        startKeepAlive(connection.remotePeer, service)
+        if (enableKeepAlive) { startKeepAlive(connection.remotePeer, service) }
         telemetry.increaseCount('bitswap-total-connections')
         telemetry.increaseCount('bitswap-active-connections')
       } catch (err) {
@@ -311,7 +312,7 @@ async function startService({ peerId, currentPort, dispatcher, announceAddr } = 
 
     service.connectionManager.on('peer:disconnect', connection => {
       try {
-        stopKeepAlive(connection.remotePeer)
+        if (enableKeepAlive) { stopKeepAlive(connection.remotePeer) }
         telemetry.decreaseCount('bitswap-active-connections')
       } catch (err) {
         logger.warn({ err, remotePeer: connection.remotePeer }, `Error while peer disconnecting: ${serializeError(err)}`)


### PR DESCRIPTION
I'd like to disable the `keep-alive` to check if the memory-leak is related to it, and if performance decrease