### PR TITLE
fix: aws expired credentials fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitswap-peer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.196.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitswap-peer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Elastic IPFS BitSwap Peer",
   "homepage": "https://github.com/elastic-ipfs/bitswap-peer",
   "license": "(Apache-2.0 AND MIT)",

--- a/src/aws-client/Client.js
+++ b/src/aws-client/Client.js
@@ -202,7 +202,12 @@ class Client {
       throw new Error('NOT_FOUND')
     }
     if (statusCode >= 400) {
-      throw new Error(`S3 request error - Status: ${statusCode} Body: ${buffer.slice().toString('utf-8')} `)
+      const content = buffer.slice().toString('utf-8')
+      // hotfix TODO port to core-lib
+      if (content.includes('ExpiredTokenException')) {
+        await this.refreshCredentials()
+      }
+      throw new Error(`S3 request error - Status: ${statusCode} Body: ${content} `)
     }
 
     return buffer.slice()
@@ -357,6 +362,10 @@ class Client {
     const content = buffer.slice().toString('utf-8')
 
     if (statusCode >= 400) {
+      // hotfix TODO port to core-lib
+      if (content.includes('ExpiredTokenException')) {
+        await this.refreshCredentials()
+      }
       throw new Error(`Dynamo request error - Status: ${statusCode} Body: ${content} `)
     }
 


### PR DESCRIPTION
as titled, run `refreshCredentials` on 

```txt
{&quot;err&quot;:&quot;[Error] Dynamo request error - Status: 400 Body: {\&quot;__type\&quot;:\&quot;com.amazon.coral.service#ExpiredTokenException\&quot;,\&quot;message\&quot;:\&quot;The security token included in the request is expired\&quot;} \nError: Dynamo request error - Status: 400 Body: {\&quot;__type\&quot;:\&quot;com.amazon.coral.service#ExpiredTokenException\&quot;,\&quot;message\&quot;:\&quot;The security token included in the request is expired\&quot;} \n at Client.dynamoRequest (file:///app/src/aws-client/Client.js:360:13)\n at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n at async Client.dynamoQueryBySortKey (file:///app/src/aws-client/Client.js:242:18)\n at async Promise.all (index 0)\n at async checkReadiness (file:///app/src/health-check.js:6:5)&quot;,&quot;key&quot;:{&quot;blockmultihash&quot;:&quot;readiness&quot;},&quot;level&quot;:50,&quot;msg&quot;:&quot;Cannot Dynamo.Query after 3 attempts&quot;,&quot;table&quot;:&quot;prod-ep-v1-blocks-cars-position&quot;,&quot;time&quot;:&quot;2022-11-21T11:27:03.746Z&quot;,&quot;v&quot;:&quot;0.6.2&quot;}
```
