### PR TITLE
docs: add contribute and release process to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,15 @@ will set the state of DynamoDB to error, and the following call to `/readiness` 
 ## Issues
 
 Please report issues in the [elastic-ipfs/elastic-ipfs repo](https://github.com/elastic-ipfs/elastic-ipfs/issues).
+
+## Contribute and release process
+
+This is the process to contribute and get a new build deployed:
+
+- Create a Pull Request with the intended change
+- Get a review from one of the team members
+- Deploy the Pull Request branch into a dev build using Github Action `Dev | Build And Deploy` and selecting branch
+- Run [`bitswap-e2e-tests`](https://github.com/elastic-ipfs/bitswap-e2e-tests/actions/workflows/dispatch-regressions.yaml) for the `Dev` build.
+- Merge Pull Request after being approved
+- Staging release will be automatically created
+- Production release will need to be authorized by one of the admins of the repo.


### PR DESCRIPTION
Adds contribute and release process guidelines similarly to https://github.com/elastic-ipfs/indexer-lambda/pull/74