### PR TITLE
fix: not send messages when cancel entry in wantlist

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -4,7 +4,7 @@ import { fetchBlocksData, fetchBlocksInfo } from './storage.js'
 import { telemetry } from './telemetry.js'
 import { connectPeer } from './networking.js'
 import { sizeofBlockInfo } from './util.js'
-import { TELEMETRY_TYPE_DATA, TELEMETRY_TYPE_INFO } from './constants.js'
+import { TELEMETRY_TYPE_DATA, TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED } from './constants.js'
 
 function createContext ({ service, peerId, protocol, wantlist, awsClient, connection, connectionId }) {
   const context = {
@@ -100,6 +100,12 @@ async function batchFetch (blocks, context, logger) {
         continue
       }
       block.key = key
+
+      // Skip block cancel
+      if (block.cancel) {
+        telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED])
+        continue
+      }
 
       if (block.wantType === Entry.WantType.Block) {
         // telemetry.increaseLabelCount('bitswap-request', [context.connectionId, TELEMETRY_TYPE_DATA])

--- a/src/handler.js
+++ b/src/handler.js
@@ -103,7 +103,10 @@ async function batchFetch (blocks, context, logger) {
 
       // Skip block cancel
       if (block.cancel) {
-        telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED])
+        const type = block.wantType === Entry.WantType.Block
+          ? TELEMETRY_TYPE_DATA
+          : TELEMETRY_TYPE_INFO
+        telemetry.increaseLabelCount('bitswap-block', [type, TELEMETRY_RESULT_CANCELED])
         continue
       }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,7 +4,7 @@ import LRUCache from 'mnemonist/lru-cache.js'
 import config from './config.js'
 import { logger } from './logging.js'
 import { telemetry } from './telemetry.js'
-import { TELEMETRY_TYPE_DATA, TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED, TELEMETRY_RESULT_ERROR, TELEMETRY_RESULT_HITS, TELEMETRY_RESULT_MISSES } from './constants.js'
+import { TELEMETRY_TYPE_DATA, TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_ERROR, TELEMETRY_RESULT_HITS, TELEMETRY_RESULT_MISSES } from './constants.js'
 
 // TODO when the v0 tables will not be used anymore, following dependencies will be removed
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
@@ -106,11 +106,6 @@ async function fetchBlocksData ({ blocks, logger, awsClient }) {
 }
 
 async function fetchBlockData ({ block, logger, awsClient }) {
-  if (block.cancel) {
-    telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_DATA, TELEMETRY_RESULT_CANCELED])
-    return
-  }
-
   if (!block.key) {
     logger.error({ block }, 'invalid block, missing key')
     telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_DATA, TELEMETRY_RESULT_ERROR])
@@ -171,11 +166,6 @@ async function fetchBlocksInfo ({ blocks, logger, awsClient }) {
 }
 
 async function fetchBlockInfo ({ block, logger, awsClient }) {
-  if (block.cancel) {
-    telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED])
-    return
-  }
-
   if (!block.key) {
     logger.error({ block }, 'invalid block, missing key')
     telemetry.increaseLabelCount('bitswap-block', [TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_ERROR])


### PR DESCRIPTION
This PR makes sure we do not send messages with block bytes for entries in the wantlist that have cancel boolean `true`.

In current behaviour, we perform a check for cancel message in [storage.js#L109-L112](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/storage.js#L109-L112) and [storage.js#L174-L177](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/storage.js#L174-L177). This check makes sure we do [not read bytes from S3 and add them to cache](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/storage.js#L148-L153). However, in the bitswap [protocol handler](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/handler.js#L122-L126) we also return these messages from `batchFetch` function and call `batchResponse` function with them to send bitswap messages. Therefore, despite not reading from S3 and putting in cache, if it will be in cache it will be ready to be served and send function will treat this wantlist entry like any other.

Proposed solution does not add `cancel === true` wantlist entries to the `fetchedBlocks` because they are really not fetched, and it will be guaranteed that bytes won't be sent over for these.

Note that doing this change, telemetry calls were changed to `handler.js`. I was not sure if that should be the case, but given we use telemetry also in the `handler` it looks like it makes sense to. When looking into options for this, I also noticed that we fail if key is invalid and [have telemetry counters](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/handler.js#L97-L102) for this in `handlers.js`. We also have exactly same checks in [storage.js](https://github.com/elastic-ipfs/bitswap-peer/blob/main/src/storage.js#L114-L117). This code looks redundant given it seems like it will never be triggered per the validation in `handlers.js`. However, I will validate this in other PR.