### PR TITLE
feat: handle cancel messages

### DIFF
--- a/metrics.yml
+++ b/metrics.yml
@@ -31,6 +31,14 @@ metrics:
       description: Amount of data sent, by type (info, data), in bytes
       labels:
         - type
+    bitswap-cancel-size:
+     description: Block total size for canceled requests
+     labels:
+        - type
+    bitswap-block-success-cancel:
+      description: Block canceled requests
+      labels:
+        - type
   durations:
     bitswap-request-duration:
       description: Execution time for a request

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.17.0",
+      "version": "0.17.2",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.258.0",
@@ -27,7 +27,6 @@
         "pino": "8.8.0",
         "piscina": "3.2.0",
         "protobufjs": "7.2.0",
-        "quick-lru": "^6.1.1",
         "sodium-native": "4.0.1",
         "undici": "5.16.0",
         "xml-js": "1.6.11"
@@ -10549,17 +10548,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
-    },
-    "node_modules/quick-lru": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/rabin-wasm": {
       "version": "0.1.5",
@@ -22553,11 +22541,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
-    },
-    "quick-lru": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q=="
     },
     "rabin-wasm": {
       "version": "0.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-sqs": "3.258.0",
         "@aws-sdk/node-http-handler": "3.257.0",
         "@chainsafe/libp2p-noise": "11.0.0",
-        "@chainsafe/libp2p-yamux": "^3.0.5",
+        "@chainsafe/libp2p-yamux": "3.0.5",
         "@libp2p/mplex": "7.1.1",
         "@libp2p/peer-id": "2.0.1",
         "@libp2p/peer-id-factory": "2.0.1",
@@ -27,6 +27,7 @@
         "pino": "8.8.0",
         "piscina": "3.2.0",
         "protobufjs": "7.2.0",
+        "quick-lru": "^6.1.1",
         "sodium-native": "4.0.1",
         "undici": "5.16.0",
         "xml-js": "1.6.11"
@@ -4022,6 +4023,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/caniuse-lite": {
@@ -10541,12 +10551,14 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rabin-wasm": {
@@ -17484,6 +17496,14 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+          "dev": true
+        }
       }
     },
     "caniuse-lite": {
@@ -22535,10 +22555,9 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q=="
     },
     "rabin-wasm": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pino": "8.8.0",
     "piscina": "3.2.0",
     "protobufjs": "7.2.0",
+    "quick-lru": "^6.1.1",
     "sodium-native": "4.0.1",
     "undici": "5.16.0",
     "xml-js": "1.6.11"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "pino": "8.8.0",
     "piscina": "3.2.0",
     "protobufjs": "7.2.0",
-    "quick-lru": "^6.1.1",
     "sodium-native": "4.0.1",
     "undici": "5.16.0",
     "xml-js": "1.6.11"

--- a/src/handler.js
+++ b/src/handler.js
@@ -6,7 +6,7 @@ import { connectPeer } from './networking.js'
 import { sizeofBlockInfo } from './util.js'
 import { TELEMETRY_TYPE_DATA, TELEMETRY_TYPE_INFO, TELEMETRY_RESULT_CANCELED } from './constants.js'
 
-function createContext ({ service, peerId, protocol, wantlist, awsClient, connection, connectionId }) {
+function createContext ({ service, peerId, protocol, wantlist, awsClient, connection, connectionId, inProcessingWantBlocks, inProcessingWantHaves }) {
   const context = {
     state: 'ok',
     connection,
@@ -21,8 +21,8 @@ function createContext ({ service, peerId, protocol, wantlist, awsClient, connec
     batchesTodo: 0,
     batchesDone: 0,
     connectionId,
-    inProcessingWantBlocks: new Map(),
-    inProcessingWantHaves: new Map()
+    inProcessingWantBlocks,
+    inProcessingWantHaves
   }
   return context
 }

--- a/src/handler.js
+++ b/src/handler.js
@@ -15,12 +15,14 @@ function createContext ({ service, peerId, protocol, wantlist, awsClient, connec
     service,
     peerId,
     protocol,
-    blocks: wantlist.entries,
+    wantlist: wantlist.entries,
     done: 0,
     todo: 0,
     batchesTodo: 0,
     batchesDone: 0,
-    connectionId
+    connectionId,
+    inProcessingWantBlocks: new Map(),
+    inProcessingWantHaves: new Map()
   }
   return context
 }
@@ -28,16 +30,16 @@ function createContext ({ service, peerId, protocol, wantlist, awsClient, connec
 function handle ({ context, logger, batchSize = config.blocksBatchSize }) {
   return telemetry.trackDuration('bitswap-request-duration',
     new Promise(resolve => {
-      if (context.blocks.length < 1) {
+      if (context.wantlist.length < 1) {
         resolve()
         return
       }
 
-      context.todo = context.blocks.length
+      context.todo = context.wantlist.length
       telemetry.increaseCount('bitswap-total-entries', context.todo)
       telemetry.increaseGauge('bitswap-pending-entries', context.todo)
 
-      let blocksLength
+      let wantlistLength
       context.batchesTodo = Math.ceil(context.todo / batchSize)
       // const hrTime = process.hrtime()
       // const requestId = hrTime[0] * 1000000000 + hrTime[1]
@@ -45,13 +47,18 @@ function handle ({ context, logger, batchSize = config.blocksBatchSize }) {
       // telemetry.increaseLabelCount('bitswap-request-size', [context.connectionId, requestId], context.todo)
 
       do {
-        const blocks = context.blocks.splice(0, batchSize)
-
-        if (blocks.length === 0) {
+        const wantlist = context.wantlist.splice(0, batchSize)
+        if (wantlist.length === 0) {
           break
         }
+        wantlistLength = wantlist.length
 
-        blocksLength = blocks.length
+        // normalize wantlist into different wantlist operations
+        const normalizedWantlist = getNormalizedWantlist(wantlist, context, logger)
+
+        // Set state of processing blocks
+        setProcessingBlocks(normalizedWantlist, context)
+
         process.nextTick(async () => {
           // catch async error in libp2p connection
           try {
@@ -59,11 +66,15 @@ function handle ({ context, logger, batchSize = config.blocksBatchSize }) {
             // in those cases skip fetching and response, iterate pending batches and close
             if (context.state === 'ok') {
               // append content to its block
-              const fetched = await batchFetch(blocks, context, logger)
+              const fetched = await batchFetch(normalizedWantlist, context, logger)
+
               // close connection on last batch
               await batchResponse({ blocks: fetched, context, logger })
             }
           } catch (err) {
+            // Cleanup in processing blocks
+            clearProcessingBlocks(normalizedWantlist, context)
+
             // TODO remove? probably not needed
             logger.error({ err }, 'error on handler#nextTick end response')
           }
@@ -79,62 +90,79 @@ function handle ({ context, logger, batchSize = config.blocksBatchSize }) {
             logger.error({ err }, 'error on handler#nextTick end response')
           }
         })
-      } while (blocksLength === batchSize)
+      } while (wantlistLength === batchSize)
     }))
+}
+
+function getNormalizedWantlist (blocks, context, logger) {
+  const wantedBlocks = []
+  const wantedHave = []
+  const canceled = []
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    const key = cidToKey(block.cid)
+    if (!key) {
+      logger.error({ block }, 'invalid block cid')
+      telemetry.increaseCount('bitswap-block-error')
+      continue
+    }
+    block.key = key
+
+    // Skip block cancel
+    if (block.cancel) {
+      const type = block.wantType === Entry.WantType.Block
+        ? TELEMETRY_TYPE_DATA
+        : TELEMETRY_TYPE_INFO
+      telemetry.increaseLabelCount('bitswap-block', [type, TELEMETRY_RESULT_CANCELED])
+      canceled.push(block)
+      continue
+    }
+
+    if (block.wantType === Entry.WantType.Block) {
+      // telemetry.increaseLabelCount('bitswap-request', [context.connectionId, TELEMETRY_TYPE_DATA])
+      block.type = BLOCK_TYPE_DATA
+      wantedBlocks.push(block)
+      continue
+    }
+    if (block.wantType === Entry.WantType.Have && context.protocol === BITSWAP_V_120) {
+      // telemetry.increaseLabelCount('bitswap-request', [context.connectionId, TELEMETRY_TYPE_INFO])
+      block.type = BLOCK_TYPE_INFO
+      wantedHave.push(block)
+      continue
+    }
+
+    // other blocks are stripped and not fetched - and not responded
+    logger.error({ block }, 'unsupported block type')
+    telemetry.increaseCount('bitswap-block-error')
+  }
+
+  return {
+    wantedBlocks,
+    wantedHave,
+    canceled
+  }
 }
 
 /**
  * fetch blocks content from storage
  * append content to its block
  */
-async function batchFetch (blocks, context, logger) {
+async function batchFetch (wantList, context, logger) {
+  const { wantedBlocks, wantedHave } = wantList
+
+  // Fetch blocks
   try {
-    const dataBlocks = []
-    const infoBlocks = []
-    for (let i = 0; i < blocks.length; i++) {
-      const block = blocks[i]
-      const key = cidToKey(block.cid)
-      if (!key) {
-        logger.error({ block }, 'invalid block cid')
-        telemetry.increaseCount('bitswap-block-error')
-        continue
-      }
-      block.key = key
-
-      // Skip block cancel
-      if (block.cancel) {
-        const type = block.wantType === Entry.WantType.Block
-          ? TELEMETRY_TYPE_DATA
-          : TELEMETRY_TYPE_INFO
-        telemetry.increaseLabelCount('bitswap-block', [type, TELEMETRY_RESULT_CANCELED])
-        continue
-      }
-
-      if (block.wantType === Entry.WantType.Block) {
-        // telemetry.increaseLabelCount('bitswap-request', [context.connectionId, TELEMETRY_TYPE_DATA])
-        block.type = BLOCK_TYPE_DATA
-        dataBlocks.push(block)
-        continue
-      }
-      if (block.wantType === Entry.WantType.Have && context.protocol === BITSWAP_V_120) {
-        // telemetry.increaseLabelCount('bitswap-request', [context.connectionId, TELEMETRY_TYPE_INFO])
-        block.type = BLOCK_TYPE_INFO
-        infoBlocks.push(block)
-        continue
-      }
-
-      // other blocks are stripped and not fetched - and not responded
-      logger.error({ block }, 'unsupported block type')
-      telemetry.increaseCount('bitswap-block-error')
-    }
-
     await Promise.all([
-      fetchBlocksInfo({ blocks: infoBlocks, logger, awsClient: context.awsClient }),
-      fetchBlocksData({ blocks: dataBlocks, logger, awsClient: context.awsClient })
+      fetchBlocksInfo({ blocks: wantedHave, logger, awsClient: context.awsClient }),
+      fetchBlocksData({ blocks: wantedBlocks, logger, awsClient: context.awsClient })
     ])
-    return [...infoBlocks, ...dataBlocks]
+    return [...wantedHave, ...wantedBlocks]
   } catch (err) {
     logger.error({ err }, 'error on handler#batchFetch')
+
+    // guarantee inProcessing cleanup
+    throw err
   }
 }
 
@@ -162,23 +190,83 @@ async function batchResponse ({ blocks, context, logger }) {
     let message = new Message()
     for (let i = 0; i < blocks.length; i++) {
       const block = blocks[i]
+      const inProcessingMap = getInProcessingMap(block, context)
+      const inProcessingBlock = inProcessingMap.get(block.key)
 
-      const size = messageSize[block.type](block)
-      // maxMessageSize MUST BE larger than a single block info/data
-      if (message.size() + size > config.maxMessageSize) {
-        await message.send(context)
-        message = new Message()
+      if (!inProcessingBlock?.cancel) {
+        const size = messageSize[block.type](block)
+
+        // maxMessageSize MUST BE larger than a single block info/data
+        if (message.size() + size > config.maxMessageSize) {
+          await message.send(context)
+          message = new Message()
+        }
+
+        message.push(block, size, context.protocol)
+        sentMetrics[block.type](block, size)
       }
 
-      message.push(block, size, context.protocol)
-      sentMetrics[block.type](block, size)
+      // Delete in processing blocks
+      inProcessingMap.delete(block.key)
     }
 
     await message.send(context)
     context.done += blocks.length
   } catch (err) {
     logger.error({ err }, 'error on handler#batchResponse')
+
+    // guarantee inProcessing cleanup
+    throw err
   }
+}
+
+function setProcessingBlocks (wantList, context) {
+  const { wantedBlocks, wantedHave, canceled } = wantList
+  const now = Date.now()
+
+  canceled.forEach(block => {
+    const inProcessing = getInProcessingMap(block, context)
+
+    if (inProcessing.has(block.key)) {
+      inProcessing.set(block.key, {
+        cancel: now
+      })
+    }
+  })
+
+  // Add new blocks in process
+  wantedBlocks.forEach(block => {
+    const inProcessing = getInProcessingMap(block, context)
+
+    inProcessing.set(block.key, {})
+  })
+
+  wantedHave.forEach(block => {
+    const inProcessing = getInProcessingMap(block, context)
+
+    inProcessing.set(block.key, {})
+  })
+}
+
+function clearProcessingBlocks (wantList, context) {
+  const { wantedBlocks, wantedHave } = wantList
+
+  // Clear blocks in process
+  wantedBlocks.forEach(block => {
+    const inProcessing = getInProcessingMap(block, context)
+    inProcessing.delete(block.key)
+  })
+
+  wantedHave.forEach(block => {
+    const inProcessing = getInProcessingMap(block, context)
+    inProcessing.set(block.key)
+  })
+}
+
+function getInProcessingMap (block, context) {
+  return block.wantType === Entry.WantType.Block
+    ? context.inProcessingWantBlocks
+    : context.inProcessingWantHaves
 }
 
 // end response, close connection

--- a/src/service.js
+++ b/src/service.js
@@ -4,7 +4,7 @@ import { webSockets } from '@libp2p/websockets'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 // import { yamux } from '@chainsafe/libp2p-yamux'
-import LRU from 'quick-lru'
+import LRU from 'lru-cache'
 
 import { noiseCrypto } from './noise-crypto.js'
 import { Message, protocols } from 'e-ipfs-core-lib'
@@ -109,7 +109,7 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
       service.handle(protocol, async ({ connection: dial, stream }) => {
         try {
           const connection = new Connection(stream)
-          const canceled = new LRU({ maxSize: 200 })
+          const canceled = new LRU({ max: 200 })
 
           const hrTime = process.hrtime()
           const connectionId = hrTime[0] * 1000000000 + hrTime[1]

--- a/src/service.js
+++ b/src/service.js
@@ -124,7 +124,14 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
             }
 
             try {
-              const context = createContext({ service, peerId: dial.remotePeer, protocol, wantlist: message.wantlist, awsClient, connectionId })
+              const context = createContext({
+                service,
+                peerId: dial.remotePeer,
+                protocol,
+                wantlist: message.wantlist,
+                awsClient,
+                connectionId
+              })
               process.nextTick(handle, { context, logger })
             } catch (err) {
               logger.error({ err }, 'Error creating context')

--- a/src/service.js
+++ b/src/service.js
@@ -4,6 +4,7 @@ import { webSockets } from '@libp2p/websockets'
 import { noise } from '@chainsafe/libp2p-noise'
 import { mplex } from '@libp2p/mplex'
 // import { yamux } from '@chainsafe/libp2p-yamux'
+import LRU from 'quick-lru'
 
 import { noiseCrypto } from './noise-crypto.js'
 import { Message, protocols } from 'e-ipfs-core-lib'
@@ -108,8 +109,7 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
       service.handle(protocol, async ({ connection: dial, stream }) => {
         try {
           const connection = new Connection(stream)
-          const inProcessingWantBlocks = new Map()
-          const inProcessingWantHaves = new Map()
+          const canceled = new LRU({ maxSize: 200 })
 
           const hrTime = process.hrtime()
           const connectionId = hrTime[0] * 1000000000 + hrTime[1]
@@ -133,8 +133,7 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
                 wantlist: message.wantlist,
                 awsClient,
                 connectionId,
-                inProcessingWantBlocks,
-                inProcessingWantHaves
+                canceled
               })
               process.nextTick(handle, { context, logger })
             } catch (err) {
@@ -145,9 +144,15 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
           // When the incoming duplex stream finishes sending, close for writing.
           // Note: we never write to this stream - responses are always sent on
           // another multiplexed stream.
-          connection.on('end:receive', () => connection.close())
+          connection.on('end:receive', () => {
+            // GC canceled LRU on finish
+            canceled.clear()
+            connection.close()
+          })
 
           connection.on('error', err => {
+            // GC canceled LRU on error
+            canceled.clear()
             logger.error({ err, dial, stream, protocol }, 'Connection error')
           })
         } catch (err) {

--- a/src/service.js
+++ b/src/service.js
@@ -108,6 +108,8 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
       service.handle(protocol, async ({ connection: dial, stream }) => {
         try {
           const connection = new Connection(stream)
+          const inProcessingWantBlocks = new Map()
+          const inProcessingWantHaves = new Map()
 
           const hrTime = process.hrtime()
           const connectionId = hrTime[0] * 1000000000 + hrTime[1]
@@ -130,7 +132,9 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
                 protocol,
                 wantlist: message.wantlist,
                 awsClient,
-                connectionId
+                connectionId,
+                inProcessingWantBlocks,
+                inProcessingWantHaves
               })
               process.nextTick(handle, { context, logger })
             } catch (err) {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -32,11 +32,14 @@ async function spyContext ({ blocks, protocol = BITSWAP_V_120, peerId }) {
     close: sinon.spy(),
     removeAllListeners: sinon.spy()
   }
+  const inProcessingWantBlocks = new Map()
+  const inProcessingWantHaves = new Map()
+
   const peer = peerId || dummyPeer()
 
   const { awsClient } = await mockAwsClient(config)
   awsClient.agent = createMockAgent()
-  const context = createContext({ awsClient, service, peerId: peer, wantlist: new WantList(blocks), protocol, connection: connectionSpy })
+  const context = createContext({ awsClient, service, peerId: peer, wantlist: new WantList(blocks), protocol, connection: connectionSpy, inProcessingWantBlocks, inProcessingWantHaves })
   return context
 }
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -2,7 +2,7 @@
 import t from 'tap'
 import sinon from 'sinon'
 import { CID } from 'multiformats/cid'
-import LRU from 'quick-lru'
+import LRU from 'lru-cache'
 
 import config from '../src/config.js'
 import { cidToKey, BITSWAP_V_120, Entry, BlockPresence, WantList } from 'e-ipfs-core-lib'
@@ -33,7 +33,7 @@ async function spyContext ({ blocks, protocol = BITSWAP_V_120, peerId }) {
     close: sinon.spy(),
     removeAllListeners: sinon.spy()
   }
-  const canceled = new LRU({ maxSize: 200 })
+  const canceled = new LRU({ max: 200 })
 
   const peer = peerId || dummyPeer()
 


### PR DESCRIPTION
This PR adds handling of cancel messages from inflight operations. Using `p-queue` together with Abort Signal all the way would be my ideal solution, but that would require a huge refactor that would mean a long time to work on this.

Implementation details:
- added `inProcessingWantBlocks` and `inProcessingWantHaves` Maps to the handler context (each connection has its own context)
- decoupled previous `batchFetch` function into two function, with an initial step just for getting a normalized wantList with arrays for `wantedBlocks`, `wantedHave` and `canceled`
- `wantedBlocks` and `wantedHave` added to respective processing maps in the start of fetching, and canceled blocks flagged in respective processing maps (if still existing and not previously addressed)
- cleanup `inProcessing` maps in case of errors and messages not handled to avoid memory leaks

Closes https://github.com/web3-storage/w3infra/issues/149