### PR TITLE
fix: cancel message check

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -145,8 +145,6 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
           // Note: we never write to this stream - responses are always sent on
           // another multiplexed stream.
           connection.on('end:receive', () => {
-            // GC canceled LRU on finish
-            canceled.clear()
             connection.close()
           })
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -197,7 +197,7 @@ t.test('handle', async t => {
 
     await handle({ context: contextSpy, logger: loggerSpy, batchSize: 1 })
 
-    t.equal(connectionSpy.send.callCount, 2) // Only two sends in the 4 block messages
+    t.equal(connectionSpy.send.callCount, 1) // Only one sends in the 4 block messages given other gets canceled
   })
 
   t.test('should handle a request with single batch canceling requested items', async t => {
@@ -356,7 +356,7 @@ t.test('handle', async t => {
     ])
 
     t.equal(response.blocksInfo.length, 2)
-    t.equal(response.blocksData.length, 2)
+    t.equal(response.blocksData.length, 1)
 
     t.ok(responseContainsInfo(response, cid7, BlockPresence.Type.Have))
     t.ok(responseContainsInfo(response, cid9, BlockPresence.Type.Have))


### PR DESCRIPTION
Fixes cancel message check on LRU.

Couple of issues:
- `end:received` can happen on a normal connection when stream is flushed, but connection is still running
- `block.type` would actually work with one type of requests, but not both
- `block.wantType` can be 0, and therefore flipped if...else