### PR TITLE
fix: cancel state at connection scope instead of stream

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -110,7 +110,7 @@ async function startService ({ peerId, port, peerAnnounceAddr, awsClient, connec
       service.handle(protocol, async ({ connection: dial, stream }) => {
         try {
           const connection = new Connection(stream)
-          const canceled = cancelsPerPeer.get(dial.remotePeer.toString())
+          const canceled = cancelsPerPeer.get(dial.remotePeer.toString()) || new LRU({ max: 200 })
 
           const hrTime = process.hrtime()
           const connectionId = hrTime[0] * 1000000000 + hrTime[1]


### PR DESCRIPTION
Doing some extra tests with dev setup, noticed another issue.

Looks like depending on how messages are propagated in bitswap stream (likely when stream is fully flushed), the write side stream is closed and a new one is open when more messages are sent. This was resulting in a new state where 2 LRU instances can exist for same connection but different streams. This moves the scope to the connection level on `peer:connect` and `peer:disconnect`, making my local tests with dev environment not having this sporadic cancels not fulfilled 