### PR TITLE
feat: add metric counters for sent block by CID prefix

### DIFF
--- a/metrics.yml
+++ b/metrics.yml
@@ -67,5 +67,5 @@ metrics:
       description: Bitswap Event Loop Utilization
       interval: 500
 
-version: 0.2.1
-buildDate: "20230302.0953"
+version: 0.3.0
+buildDate: "20230426.1252"

--- a/metrics.yml
+++ b/metrics.yml
@@ -31,6 +31,13 @@ metrics:
       description: Amount of data sent, by type (info, data), in bytes
       labels:
         - type
+    bitswap-sent-cid-prefix:
+      description: CID prefix information of sent blocks (CID version, IPLD code, multihash code, multihash size)
+      labels:
+        - version
+        - code
+        - mh_code
+        - mh_size
     bitswap-cancel-size:
      description: Block total size for canceled requests
      labels:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.18.0",
+      "version": "0.18.2",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.258.0",

--- a/src/handler.js
+++ b/src/handler.js
@@ -187,15 +187,20 @@ async function batchResponse ({ blocks, context, logger }) {
     for (let i = 0; i < blocks.length; i++) {
       const block = blocks[i]
       const canceledItem = context.canceled.get(block.key)
+      const size = messageSize[block.type](block)
 
       if (canceledItem === block.wantType) {
-        const size = messageSize[block.type](block)
         telemetry.increaseLabelCount('bitswap-block-success-cancel', [block.type])
         telemetry.increaseLabelCount('bitswap-cancel-size', [block.type], size)
 
         context.canceled.delete(block.key)
       } else {
-        const size = messageSize[block.type](block)
+        telemetry.increaseLabelCount('bitswap-sent-cid-prefix', [
+          block.cid.version,
+          block.cid.code,
+          block.cid.multihash.code,
+          block.cid.multihash.size
+        ])
 
         // maxMessageSize MUST BE larger than a single block info/data
         if (message.size() + size > config.maxMessageSize) {


### PR DESCRIPTION
Adds a metric `bitswap-sent-cid-prefix` with lables for CID prefix values.

Definition of CID prefix: https://github.com/ipfs/go-cid/blob/829c826f6be23320846f4b7318aee4d17bf8e094/cid.go#L542-L554