### PR TITLE
feat: build images for arm

### DIFF
--- a/.github/workflows/shared-build.yaml
+++ b/.github/workflows/shared-build.yaml
@@ -66,6 +66,7 @@ jobs:
       if: inputs.docker_image_version_suffix_label != ''
       uses: docker/build-push-action@v3
       with:
+        platforms: linux/amd64,linux/arm64
         push: ${{ inputs.docker_push }}
         context: .
         tags: |
@@ -78,6 +79,7 @@ jobs:
       if: inputs.docker_image_version_suffix_label == ''
       uses: docker/build-push-action@v3
       with:
+        platforms: linux/amd64,linux/arm64
         push: ${{ inputs.docker_push }}
         context: .
         tags: |


### PR DESCRIPTION
add `platforms: linux/amd64,linux/arm64` to the docker build config to build for both x64 and arm.

see: https://github.com/elastic-ipfs/infrastructure

License: MIT