### PR TITLE
fix: dont use package version for image tag

### DIFF
--- a/.github/workflows/shared-build.yaml
+++ b/.github/workflows/shared-build.yaml
@@ -14,9 +14,6 @@ on:
         required: false
         default: true
     outputs:
-      package_version:
-        description: package_version
-        value: ${{ jobs.build.outputs.package_version }}
       build_date:
         description: build_date
         value: ${{ jobs.build.outputs.build_date }}
@@ -70,7 +67,6 @@ jobs:
         push: ${{ inputs.docker_push }}
         context: .
         tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:${{ env.PACKAGE_VERSION }}-${{ inputs.docker_image_version_suffix_label }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:${{ env.BUILD_DATE }}-${{ inputs.docker_image_version_suffix_label }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:${{ inputs.docker_image_version_suffix_label }}
         labels: |
@@ -83,7 +79,6 @@ jobs:
         push: ${{ inputs.docker_push }}
         context: .
         tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:${{ env.PACKAGE_VERSION }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:${{ env.BUILD_DATE }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/app:latest
         labels: |
@@ -91,5 +86,4 @@ jobs:
     - name: Set output variables
       id: setOutput
       run: |
-        echo "package_version=${{ env.PACKAGE_VERSION }}" >> $GITHUB_OUTPUT
         echo "build_date=${{ env.BUILD_DATE }}" >> $GITHUB_OUTPUT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitswap-peer",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitswap-peer",
-      "version": "0.18.2",
+      "version": "0.19.3",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.258.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitswap-peer",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Elastic IPFS BitSwap Peer",
   "homepage": "https://github.com/elastic-ipfs/bitswap-peer",
   "license": "(Apache-2.0 AND MIT)",


### PR DESCRIPTION
its error prone. if we forget to update the version we overwrite an existing tag.

we already have timestamp based tags. just use those.

fixes: https://github.com/elastic-ipfs/elastic-ipfs/issues/29