### PR TITLE
fix: dont reset counters & durations after each scrape

### DIFF
--- a/src/http-server.js
+++ b/src/http-server.js
@@ -69,10 +69,7 @@ class HttpServer {
           })
           telemetry.export().then(result => {
             res.end(result)
-            telemetry.resetCounters()
-            telemetry.resetDurations()
-          }
-          )
+          })
           break
         }
         default:


### PR DESCRIPTION
prom counters are _up_ only. we should not be resetting them after each scrape.

duration histograms are also designed to accumulate information over time, they should not need to be reset either.

fixes: https://github.com/elastic-ipfs/elastic-ipfs/issues/35

License: MIT